### PR TITLE
Fix runtime safety: renderer lifecycle, loop exit, and fps limiter

### DIFF
--- a/src/engine/game.cpp
+++ b/src/engine/game.cpp
@@ -40,7 +40,7 @@ void Game::run()
 	int frame = 0;
 	auto lastTime = dtclock::now();
 	int fpsLimit = 0;
-	float fpsLimTick = 1.0f / fpsLimit;
+	float fpsLimTick = fpsLimit > 0 ? 1.0f / static_cast<float>(fpsLimit) : 0.0f;
 	float gameTime = 0.0f; //Time since game start, use for framerate independent motion eg trig anim
 	float dtFac = 1.0f; // dt as ratio; shouldn't change anything if you multiply with it and you're running at 60fps
 
@@ -95,6 +95,7 @@ void Game::run()
 
 	float fpsRunningTotal = 0;
 	int runningAvgPeriodFrames = 30;
+	bool quitRequested = false;
 	do
 	{
 		auto currentTime = dtclock::now();
@@ -123,7 +124,8 @@ void Game::run()
 		gk = SDL_GetKeyboardState(NULL); 
 		while (SDL_PollEvent(&event)){
 			if (event.type == SDL_QUIT || gk[SDL_SCANCODE_ESCAPE]) {
-				break;  
+				quitRequested = true;
+				break;
 			}
 			if (event.type == SDL_MOUSEMOTION)
 			{
@@ -155,17 +157,17 @@ void Game::run()
 
 		if (gk[SDL_SCANCODE_LALT] && gk[SDL_SCANCODE_1])
 		{
-			this->renderer->~cRenderer();
+			delete this->renderer;
 			this->renderer = new cRenderer(globScreenwidth / 1, globScreenheight / 1);
 		} 
 		if (gk[SDL_SCANCODE_LALT] && gk[SDL_SCANCODE_2])
 		{
-			this->renderer->~cRenderer();
+			delete this->renderer;
 			this->renderer = new cRenderer(globScreenwidth / 2, globScreenheight / 2);
 		} 
 		if (gk[SDL_SCANCODE_LALT] && gk[SDL_SCANCODE_3])
 		{
-			this->renderer->~cRenderer();
+			delete this->renderer;
 			this->renderer = new cRenderer(globScreenwidth / 3, globScreenheight / 3);
 		} 
 
@@ -190,18 +192,12 @@ void Game::run()
 		}
 
 	}
-	while (event.type != SDL_QUIT && !gk[SDL_SCANCODE_ESCAPE]);
+	while (!quitRequested);
 
 	return;
-	// lol, lmao even
-	system("pause");
-
-	//SDL_Quit();
-
-	return;
-} 
+}
 
 Game::~Game()
 {
-	//SDL_DestroyTexture(this->screenTexture);
+	delete this->renderer;
 }

--- a/src/engine/render/render.cpp
+++ b/src/engine/render/render.cpp
@@ -35,6 +35,9 @@ cRenderer::cRenderer(int renderwidth, int renderheight)
 	this->winSurface = NULL;
 	this->window = NULL;
 	this->sdlRenderer = NULL;
+	this->screenTexture = NULL;
+	this->razor3d = nullptr;
+	this->hairline = nullptr;
 
 	int result;
 	result = SDL_Init(SDL_INIT_EVERYTHING);
@@ -64,6 +67,11 @@ cRenderer::cRenderer(int renderwidth, int renderheight)
 }
 
 cRenderer::~cRenderer() {
+	delete razor3d;
+	razor3d = nullptr;
+	delete hairline;
+	hairline = nullptr;
+
 	if (screenTexture) {
 		SDL_DestroyTexture(screenTexture);
 		screenTexture = nullptr;
@@ -76,6 +84,7 @@ cRenderer::~cRenderer() {
 		SDL_DestroyWindow(window);
 		window = nullptr;
 	}
+	SDL_Quit();
 }
 
 void cRenderer::renderScene(Scene& scene) const


### PR DESCRIPTION
### Motivation
- Prevent undefined behavior from dividing by zero when FPS limiting is disabled by making the frame-limit tick safe.
- Ensure predictable loop termination by using an explicit quit flag instead of relying on transient event state.
- Fix lifetime management of the renderer and its subobjects to avoid double-destruction and resource leaks during hot-recreate and teardown.

### Description
- Initialize `fpsLimTick` with `fpsLimit > 0 ? 1.0f / static_cast<float>(fpsLimit) : 0.0f` in `Game::run()` to avoid divide-by-zero when `fpsLimit` is 0.
- Add a `bool quitRequested` flag and change the main loop to `while (!quitRequested)` and set the flag on `SDL_QUIT`/escape to reliably exit the loop.
- Replace manual destructor calls like `this->renderer->~cRenderer()` with `delete this->renderer;` before creating a new `cRenderer` instance for resize hotkeys.
- Make `Game::~Game()` release the owned `renderer` with `delete this->renderer;`.
- In `cRenderer` constructor initialize `screenTexture`, `razor3d`, and `hairline` defensively to null and in `cRenderer` destructor `delete` `razor3d`/`hairline`, destroy SDL objects, and call `SDL_Quit()` to complete shutdown.

### Testing
- Ran the build: `cmake -S . -B build && cmake --build build -j4` to validate the changes, which exercises compilation of modified translation units.
- The build failed due to unrelated portability/toolchain issues: missing `<process.h>` on this environment and a `std::tanf` usage in `general3d.cpp`, so no successful full binary was produced, but the modified files compile-step changes were applied without introducing new compilation errors in the modified lines.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f209bec3483289a86ef63d228d593)